### PR TITLE
fix(GCI82): fix rule to handle Lombok generated setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - correction of technical problem with Integration tests (because of Maven format in technical answer to "sonar-orchestrator-junit5" library)
 - upgrade JDK from 11 to 17
 - [#4](https://github.com/green-code-initiative/creedengo-java/issues/4) Improvement: "++i" statement is not so bad
+- [#113](https://github.com/green-code-initiative/creedengo-java/pull/113) fix GCI82 rule to handle Lombok generated setters
 
 ### Deleted
 

--- a/src/it/java/org/greencodeinitiative/creedengo/java/integration/tests/GCIRulesIT.java
+++ b/src/it/java/org/greencodeinitiative/creedengo/java/integration/tests/GCIRulesIT.java
@@ -440,8 +440,8 @@ class GCIRulesIT extends GCIRulesBase {
         String filePath = "src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java";
         String ruleId = "creedengo-java:GCI82";
         String ruleMsg = "The variable is never reassigned and can be 'final'";
-        int[] startLines = new int[]{7, 12, 13, 45};
-        int[] endLines = new int[]{7, 12, 13, 45};
+        int[] startLines = new int[]{13, 18, 19, 51, 82, 91};
+        int[] endLines = new int[]{13, 18, 19, 51, 83, 92};
 
         checkIssuesForFile(filePath, ruleId, ruleMsg, startLines, endLines);
     }

--- a/src/it/test-projects/creedengo-java-plugin-test-project/pom.xml
+++ b/src/it/test-projects/creedengo-java-plugin-test-project/pom.xml
@@ -32,6 +32,31 @@
             <artifactId>spring-beans</artifactId>
             <version>5.3.25</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+        </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.38</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
+++ b/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
@@ -1,8 +1,14 @@
 import java.util.logging.Logger;
+import lombok.Setter;
+import lombok.Data;
+import lombok.AccessLevel;
 
 public class MakeNonReassignedVariablesConstants {
 
     private final Logger logger = Logger.getLogger(""); // Compliant
+
+    @Setter
+    private String myLombokManagedString = "initialValue"; // Compliant
 
     private Object myNonFinalAndNotReassignedObject = new Object(); // Noncompliant {{The variable is never reassigned and can be 'final'}}
     private Object myNonFinalAndReassignedObject = new Object(); // Compliant
@@ -66,4 +72,22 @@ public class MakeNonReassignedVariablesConstants {
         logger.info(myFinalAndNotReassignedObject.toString());
     }
 
+}
+
+@Setter
+class myExtraClassWithLombokSetter {
+    private String myExtraClassString = "initialValue"; // Compliant
+    private final String myExtraClassFinalString = "initialValue"; // Compliant
+
+    @Setter(AccessLevel.NONE) //  Noncompliant {{The variable is never reassigned and can be 'final'}}
+    private String myExtraClassSetterNoneString = "initialValue";
+}
+
+@Data
+class myExtraClassWithLombokData {
+    private String myExtraClassString = "initialValue"; // Compliant
+    private final String myExtraClassFinalString = "initialValue"; // Compliant
+
+    @Setter(AccessLevel.NONE) //  Noncompliant {{The variable is never reassigned and can be 'final'}}
+    private String myExtraClassSetterNoneString = "initialValue";
 }

--- a/src/test/files/MakeNonReassignedVariablesConstants.java
+++ b/src/test/files/MakeNonReassignedVariablesConstants.java
@@ -1,8 +1,14 @@
 import java.util.logging.Logger;
+import lombok.Setter;
+import lombok.Data;
+import lombok.AccessLevel;
 
 public class MakeNonReassignedVariablesConstants {
 
     private final Logger logger = Logger.getLogger(""); // Compliant
+
+    @Setter
+    private String myLombokManagedString = "initialValue"; // Compliant
 
     private Object myNonFinalAndNotReassignedObject = new Object(); // Noncompliant {{The variable is never reassigned and can be 'final'}}
     private Object myNonFinalAndReassignedObject = new Object(); // Compliant
@@ -66,4 +72,22 @@ public class MakeNonReassignedVariablesConstants {
         logger.info(myFinalAndNotReassignedObject.toString());
     }
 
+}
+
+@Setter
+class myExtraClassWithLombokSetter {
+    private String myExtraClassString = "initialValue"; // Compliant
+    private final String myExtraClassFinalString = "initialValue"; // Compliant
+
+    @Setter(AccessLevel.NONE) //  Noncompliant {{The variable is never reassigned and can be 'final'}}
+    private String myExtraClassSetterNoneString = "initialValue";
+}
+
+@Data
+class myExtraClassWithLombokData {
+    private String myExtraClassString = "initialValue"; // Compliant
+    private final String myExtraClassFinalString = "initialValue"; // Compliant
+
+    @Setter(AccessLevel.NONE) //  Noncompliant {{The variable is never reassigned and can be 'final'}}
+    private String myExtraClassSetterNoneString = "initialValue";
 }


### PR DESCRIPTION
fix the issue #107 

Still some improvements can be done:
- Manage the case when the annotation use is  `@lombok.Setter` or `@lombok.Data` instead of just `@Setter` or `@Data`
- The rule works for the case of `import toto.Setter` or `import toto.Data` (same class has Lombok) but some TU and TI can be added.
- Eventually improve the code quality delivered (constant instead of string, test null case).

