### PR TITLE
refactor: don't unnecessarily call methods when writing with LOGGER.debug()

### DIFF
--- a/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
@@ -25,12 +25,13 @@ public class MakeNonReassignedVariablesConstants extends IssuableSubscriptionVis
     @Override
     public void visitNode(@Nonnull Tree tree) {
         VariableTree variableTree = (VariableTree) tree;
-        LOGGER.debug("Variable > " + getVariableNameForLogger(variableTree));
-        LOGGER.debug("   => isNotFinalAndNotStatic(variableTree) = " + isNotFinalAndNotStatic(variableTree));
-        LOGGER.debug("   => usages = " + variableTree.symbol().usages().size());
-        LOGGER.debug("   => isNotReassigned = " + isNotReassigned(variableTree));
-        LOGGER.debug("   => isPassedAsNonFinalParameter = " + isPassedAsNonFinalParameter(variableTree));
-
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Variable > {}", getVariableNameForLogger(variableTree));
+            LOGGER.debug("   => isNotFinalAndNotStatic(variableTree) = {}", isNotFinalAndNotStatic(variableTree));
+            LOGGER.debug("   => usages = {}", variableTree.symbol().usages().size());
+            LOGGER.debug("   => isNotReassigned = {}", isNotReassigned(variableTree));
+            LOGGER.debug("   => isPassedAsNonFinalParameter = {}", isPassedAsNonFinalParameter(variableTree));
+        }
         if (isNotFinalAndNotStatic(variableTree) && isNotReassigned(variableTree)) {
             reportIssue(tree, MESSAGE_RULE);
         } else {


### PR DESCRIPTION
In class MakeNonReassignedVariablesConstants, at the beginning of `visitNode`, some logs are written in debug mode.

The problem is these methods are called unnecessaraily if debug mode is not activate : 
- `getVariableNameForLogger`
- `isNotFinalAndNotStatic`
- `variableTree.symbol().usages().size()`
- `isNotReassigned`
- `isPassedAsNonFinalParameter`