### PR TITLE
fix: mvnw execution on windows (auto crlf > force lf)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Ensure all SH files are checked out with LF line endings (regardless of the
 # OS they were checked out on).
 *.sh text eol=lf
+mvnw text eol=lf
 
 # Ensure BAT files will always be checked out with CRLFs (regardless of the
 # OS they were checked out on).


### PR DESCRIPTION
crash when run ./tool_build.sh on docker (windows)