### PR TITLE
Gci82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#122](https://github.com/green-code-initiative/creedengo-java/issues/122) GCI82 - remove false positive triggered on pattern variables of `instanceof`, record patterns and `switch` patterns (e.g. `if (o instanceof final String s)`)
 - [#69](https://github.com/green-code-initiative/creedengo-java/issues/69) correction of NullPointer in GCI79 rule + technical refactoring of GCI79
 - update integration tests system to use the new component "creedengo-integration-test"
 - compatibility updates for SonarQube up to 26.2.0

--- a/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
+++ b/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
@@ -41,6 +41,12 @@ public class MakeNonReassignedVariablesConstants {
         logger.info(reassigned);
     }
 
+    public void parameterNotReassignedInstance() {
+        if (o instanceof final String k) {
+            logger.info(k);
+        }
+    }
+
     public void parameterNotReassigned(final String notReassigned) {
         logger.info(notReassigned);
     }
@@ -107,13 +113,13 @@ public class MakeNonReassignedVariablesConstants {
         String varDefinedInMethodReassignedInMethod = "0"; // Compliant
         String varDefinedInMethodInFinalMethod = "0"; // Noncompliant {{The variable is never reassigned and can be 'final'}}
         String varDefinedInMethodNotReassignedInMethod = "0"; // Compliant (the String was passed as a non-final parameter to the method)
-
         this.parameterReassigned(varDefinedInMethodReassignedInMethod);
         this.parameterReassigned(this.varDefinedInClassReassignedInMethod);
         this.parameterNotReassigned(varDefinedInMethodInFinalMethod);
         this.parameterNotReassigned(this.varDefinedInClassInFinalMethod);
         this.parameterNotReassignedNotFinal(varDefinedInMethodNotReassignedInMethod);
         this.parameterNotReassignedNotFinal(this.varDefinedInClassNotReassignedInMethod);
+        this.parameterNotReassignedInstance();
     }
 
     void reassignedInConstructor(){

--- a/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
+++ b/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
@@ -119,7 +119,7 @@ public class MakeNonReassignedVariablesConstants {
         this.parameterNotReassigned(this.varDefinedInClassInFinalMethod);
         this.parameterNotReassignedNotFinal(varDefinedInMethodNotReassignedInMethod);
         this.parameterNotReassignedNotFinal(this.varDefinedInClassNotReassignedInMethod);
-        this.parameterNotReassignedInstance();
+        this.parameterNotReassignedInstance();// Compliant
     }
 
     void reassignedInConstructor(){

--- a/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
+++ b/src/it/test-projects/creedengo-java-plugin-test-project/src/main/java/org/greencodeinitiative/creedengo/java/checks/GCI82/MakeNonReassignedVariablesConstants.java
@@ -42,6 +42,8 @@ public class MakeNonReassignedVariablesConstants {
     }
 
     public void parameterNotReassignedInstance() {
+        final Object o = new Object();
+        // instanceof with final keyword - Compliant (pattern variable is skipped)
         if (o instanceof final String k) {
             logger.info(k);
         }

--- a/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/java/checks/MakeNonReassignedVariablesConstants.java
@@ -25,6 +25,16 @@ public class MakeNonReassignedVariablesConstants extends IssuableSubscriptionVis
     @Override
     public void visitNode(@Nonnull Tree tree) {
         VariableTree variableTree = (VariableTree) tree;
+
+        // Issue #122 : skip pattern variables (instanceof pattern, record pattern, switch pattern).
+        // Pattern variables are scope-limited to their branch and cannot meaningfully be made
+        // "more final". SonarJava does not consistently expose the `final` modifier on pattern
+        // variables, which would produce a false positive when the user has explicitly written
+        // `final` — e.g. `if (o instanceof final String s)`.
+        if (isPatternVariable(variableTree)) {
+            return;
+        }
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Variable > {}", getVariableNameForLogger(variableTree));
             LOGGER.debug("   => isNotFinalAndNotStatic(variableTree) = {}", isNotFinalAndNotStatic(variableTree));
@@ -37,6 +47,21 @@ public class MakeNonReassignedVariablesConstants extends IssuableSubscriptionVis
         } else {
             super.visitNode(tree);
         }
+    }
+
+    /**
+     * Returns {@code true} when the given variable is a pattern variable, i.e. it is the variable
+     * bound by a type pattern in:
+     * <ul>
+     *     <li>an {@code instanceof} pattern: {@code if (o instanceof String s)}</li>
+     *     <li>a record pattern component: {@code if (p instanceof Point(int x, int y))}</li>
+     *     <li>a switch pattern: {@code case String s -> ...}</li>
+     * </ul>
+     * In all those cases, the {@code VariableTree} is the direct child of a {@code TypePatternTree}.
+     */
+    private static boolean isPatternVariable(VariableTree variableTree) {
+        Tree parent = variableTree.parent();
+        return parent != null && parent.is(Kind.TYPE_PATTERN);
     }
 
     private static boolean isNotReassigned(VariableTree variableTree) {


### PR DESCRIPTION
Analyse de la cause du faux positif
les champs de classe, paramètres de méthode, variables locales (cas légitimes du check),
les variables de pattern instanceof (Java 16+) — o instanceof String k,
les composants de record pattern (Java 21) — Point(int x, int y),
les variables de pattern switch (Java 21).
Pour if (o instanceof final ConfEntry<?> k), SonarJava construit l'AST suivant :
PatternInstanceOfTree    (Kind.PATTERN_INSTANCE_OF)
├── expression : Identifier "o"
└── pattern : TypePatternTree    (Kind.TYPE_PATTERN)
    └── patternVariable : VariableTree    (Kind.VARIABLE) ← le check tombe ici
        ├── modifiers : ModifiersTree   ← ne contient PAS toujours FINAL
        ├── type : ConfEntry<?>
        └── simpleName : "k"



Le correctif

Skipper entièrement les pattern variables — sûr, et défendable sémantiquement : une pattern variable est scope-limitée à sa branche if/case, son éventuel statut final est purement cosmétique (pas d'enjeu de réassignation cross-scope), donc la valeur green de la règle est nulle sur ce cas.

Arguments : 
Parce que la variable :

est ultra locale
vit seulement dans le bloc
ne peut pas fuiter ailleurs
n’a pas d’impact d’état global
ne crée pas de risque de mutation transverse
Donc, dans une logique d’éco-conception logicielle :

aucune réduction mémoire
aucun gain CPU
aucun impact GC
aucune amélioration de complexité
aucune réduction d’effet de bord significative
La règle “mettre final partout” devient ici du bruit statique.